### PR TITLE
Stream from HTTP source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/target
+target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,7 +1156,6 @@ version = "1.1.0"
 dependencies = [
  "arrow",
  "async-trait",
- "bytes",
  "clap 3.0.0-beta.2",
  "crossbeam-channel",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1158,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "clap 3.0.0-beta.2",
+ "crossbeam-channel",
  "lazy_static",
  "parquet",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
  "lexical-core",
  "multiversion",
  "num",
- "rand",
+ "rand 0.7.3",
  "regex",
  "serde",
  "serde_derive",
@@ -133,10 +133,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
@@ -220,6 +232,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +279,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "flatbuffers"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +311,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+
+[[package]]
+name = "futures-io"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+
+[[package]]
+name = "futures-task"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+
+[[package]]
+name = "futures-util"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+dependencies = [
+ "autocfg",
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +399,36 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -315,6 +462,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+
+[[package]]
+name = "httpdate"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+
+[[package]]
+name = "hyper"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,10 +554,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "integer-encoding"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itoa"
@@ -343,6 +587,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -369,6 +622,15 @@ name = "libc"
 version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+
+[[package]]
+name = "lock_api"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -400,10 +662,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
@@ -413,6 +687,28 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -433,6 +729,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -522,6 +845,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "openssl"
+version = "0.10.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "ordered-float"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +897,31 @@ name = "os_str_bytes"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "parquet"
@@ -571,9 +958,38 @@ dependencies = [
 name = "parquet2json"
 version = "1.0.0"
 dependencies = [
+ "bytes",
  "clap 3.0.0-beta.2",
+ "lazy_static",
  "parquet",
+ "regex",
+ "reqwest",
+ "tokio",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "ppv-lite86"
@@ -629,11 +1045,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -643,7 +1071,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -652,7 +1090,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -661,7 +1108,25 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -688,10 +1153,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -723,6 +1270,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +1307,16 @@ name = "snap"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
+
+[[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "static_assertions"
@@ -761,6 +1345,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand 0.8.4",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -844,6 +1442,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
+name = "tracing"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +1580,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +1610,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +1630,84 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+dependencies = [
+ "cfg-if",
+ "serde",
+ "serde_json",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -915,6 +1739,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "parquet2json"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "arrow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/jupiter/parquet2json"
 [dependencies]
 arrow = { version = "4.3", features = ["prettyprint"] }
 async-trait = "0.1"
-bytes = { version = "1.0.1" }
 crossbeam-channel = { version = "0.5.1" }
 clap = "3.0.0-beta.2"
 lazy_static = { version = "1.4.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/jupiter/parquet2json"
 arrow = { version = "4.3", features = ["prettyprint"] }
 async-trait = "0.1"
 bytes = { version = "1.0.1" }
+crossbeam-channel = { version = "0.5.1" }
 clap = "3.0.0-beta.2"
 lazy_static = { version = "1.4.0" }
 parquet = { version = "4.4", features = ["cli"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parquet2json"
 description = "A command-line tool for converting Parquet to newline-delimited JSON"
-version = "1.0.3"
+version = "1.1.0"
 edition = "2018"
 license = "MIT"
 authors = ["Pieter Raubenheimer <pieter@wavana.com>", "rdettai <contact@cloudfuse.io>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,8 @@ repository = "https://github.com/jupiter/parquet2json"
 [dependencies]
 clap = "3.0.0-beta.2"
 parquet = { version = "4.4.0", features = ["cli"] }
+reqwest = { version = "0.11", features = ["blocking"] }
+tokio = { version = "1", features = ["full"] }
+bytes = { version = "1.0.1" }
+lazy_static = { version = "1.4.0" }
+regex = { version = "1.5.4" }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ USAGE:
     parquet2json [OPTIONS] <FILE>
 
 ARGS:
-    <FILE>    Location of Parquet input file (path or S3 URL)
+    <FILE>    Location of Parquet input file (path, HTTP or S3 URL)
 
 FLAGS:
     -h, --help       Prints help information
@@ -49,11 +49,17 @@ $ parquet2json ./myfile.pq > output.ndjson
 $ parquet2json ./myfile.pq | jq 'select(.level==3) | .id'
 ```
 
-#### From S3
+#### From S3 or HTTP (S3)
 
 ```shell
 $ parquet2json s3://amazon-reviews-pds/parquet/product_category=Gift_Card/part-00000-495c48e6-96d6-4650-aa65-3c36a3516ddd.c000.snappy.parquet
 ```
+
+```shell
+$ parquet2json https://amazon-reviews-pds.s3.us-east-1.amazonaws.com/parquet/product_category%3DGift_Card/part-00000-495c48e6-96d6-4650-aa65-3c36a3516ddd.c000.snappy.parquet
+```
+
+Note: HTTP should be much faster and have a lower memory footprint due to the current implementation of the S3 Reader.
 
 ## License
 

--- a/src/http_reader.rs
+++ b/src/http_reader.rs
@@ -1,0 +1,129 @@
+use lazy_static::lazy_static;
+use std::thread;
+use std::sync::Arc;
+use std::io::{self, Cursor, Error, ErrorKind, Read, Seek, SeekFrom, Write};
+use parquet::errors::{Result};
+use parquet::file::reader::{ChunkReader, Length};
+use reqwest::blocking::{Client, Response};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use std::ops::Deref;
+use bytes::Bytes;
+use regex::Regex;
+use bytes::BufMut;
+
+enum Range {
+  FromPositionTo(u64, u64),
+  FromEnd(i64)
+}
+
+fn construct_headers(range: Range) -> HeaderMap {
+  let mut headers = HeaderMap::new();
+
+  let range_str = match range {
+    Range::FromPositionTo(start_pos, end_pos) => format!("bytes={}-{}", start_pos, end_pos),
+    Range::FromEnd(end_pos) => format!("bytes={}", end_pos)
+  };
+
+  headers.insert("Range", HeaderValue::from_str(range_str.as_str()).unwrap());
+  headers
+}
+
+struct ContentRange {
+  start_pos: u64,
+  end_pos: u64,
+  total_length: u64,
+}
+
+fn get_content_range(response: &Response) -> ContentRange {
+  let content_range_value = response.headers().get("Content-Range").unwrap().to_str().unwrap();
+  lazy_static! {
+    static ref BYTES_REGEX: Regex = Regex::new(
+        r"bytes (\d+)-(\d+)/([0-9*]+)"
+    ).unwrap();
+  };
+  println!("{}", content_range_value);
+  let content_range_captures = BYTES_REGEX.captures(content_range_value).unwrap();
+  
+  ContentRange {
+    start_pos: content_range_captures.get(1).unwrap().as_str().parse::<u64>().unwrap(),
+    end_pos: content_range_captures.get(2).unwrap().as_str().parse::<u64>().unwrap(),
+    total_length: content_range_captures.get(3).unwrap().as_str().parse::<u64>().unwrap(),
+  }
+}
+
+fn fetch_range(client: Arc<Client>, url: String, range: Range) -> Response {
+  // match range {
+  //   Range::FromPositionTo(from, to) => println!("{}-{}", from, to),
+  //   Range::FromEnd(length) => println!("{}", length)
+  // }
+  client.get(url).headers(construct_headers(range)).send().unwrap()
+}
+
+pub struct HttpChunkReader {
+  client: Arc<Client>,
+  url: String,
+  start_pos: u64,
+  end_pos: u64,
+  total_size: u64,
+  writer: Option<Response>
+}
+
+impl HttpChunkReader {
+  pub fn new(client: Arc<Client>, url: String, total_size: u64) -> HttpChunkReader {
+    HttpChunkReader {
+      client,
+      url,
+      start_pos: 0,
+      end_pos: 0,
+      total_size,
+      writer: None
+    }
+  }
+
+  pub fn new_unknown_size(client: Arc<Client>, url: String) -> HttpChunkReader {
+    let response = fetch_range(client.clone(), url.clone(), Range::FromEnd(-4));
+    let content_range = get_content_range(&response);
+    Self::new(client.clone(), url.clone(), content_range.total_length)
+  }
+}
+
+impl Length for HttpChunkReader {
+  fn len(&self) -> u64 {
+      self.total_size
+  }
+}
+
+impl Read for HttpChunkReader {
+  fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    println!("Read {}({})", self.start_pos, self.end_pos);
+    match self.writer.take() {
+      Some(mut writer) => {        
+        let result = Read::read(&mut writer, buf);
+        self.writer = Some(writer);
+        result
+      },
+      None => {
+        let mut writer = fetch_range(self.client.clone(), self.url.clone(), Range::FromPositionTo(self.start_pos, self.end_pos));
+        let result = Read::read(&mut writer, buf);
+        self.writer = Some(writer);        
+        result
+      }
+    }
+  }
+}
+
+impl ChunkReader for HttpChunkReader {
+  type T = HttpChunkReader;
+
+  fn get_read(&self, start_pos: u64, length: usize) -> Result<Self::T> {
+    println!("New ChunkReader {}({})", start_pos, length);
+    Ok(HttpChunkReader {
+      client: self.client.clone(),
+      url: self.url.clone(),
+      start_pos,
+      end_pos: start_pos + (length as u64) - 1,
+      total_size: self.total_size,
+      writer: None
+    })
+  }
+}

--- a/src/http_reader.rs
+++ b/src/http_reader.rs
@@ -3,204 +3,219 @@ use std::io::{self, Read};
 use std::result;
 use std::thread;
 
+use crossbeam_channel::{bounded, Receiver, Sender};
 use lazy_static::lazy_static;
-use crossbeam_channel::{Receiver, Sender, bounded};
-use parquet::errors::{Result};
+use parquet::errors::Result;
 use parquet::file::reader::{ChunkReader, Length};
+use regex::Regex;
 use reqwest::blocking::{Client, Response};
 use reqwest::header::{HeaderMap, HeaderValue};
-use regex::Regex;
 
 enum Range {
-  FromPositionTo(u64, u64),
-  FromEnd(u64)
+    FromPositionTo(u64, u64),
+    FromEnd(u64),
 }
 
 fn construct_headers(range: Range) -> HeaderMap {
-  let mut headers = HeaderMap::new();
+    let mut headers = HeaderMap::new();
 
-  let range_str = match range {
-    Range::FromPositionTo(start_pos, length) => format!("bytes={}-{}", start_pos, length),
-    Range::FromEnd(length) => format!("bytes=-{}", length)
-  };
+    let range_str = match range {
+        Range::FromPositionTo(start_pos, length) => format!("bytes={}-{}", start_pos, length),
+        Range::FromEnd(length) => format!("bytes=-{}", length),
+    };
 
-  headers.insert("Range", HeaderValue::from_str(range_str.as_str()).unwrap());
-  headers
+    headers.insert("Range", HeaderValue::from_str(range_str.as_str()).unwrap());
+    headers
 }
 
 struct ContentRange {
-  // start_pos: u64,
-  // end_pos: u64,
-  total_length: u64,
+    // start_pos: u64,
+    // end_pos: u64,
+    total_length: u64,
 }
 
 static CONTENT_RANGE_HEADER_KEY: &str = "Content-Range";
 
 fn get_content_range(response: &Response) -> ContentRange {
-  if !response.headers().contains_key(CONTENT_RANGE_HEADER_KEY) {
-    panic!("Range header not supported");
-  }
-  let content_range_value = response.headers().get(CONTENT_RANGE_HEADER_KEY).unwrap().to_str().unwrap();
-  lazy_static! {
-    static ref BYTES_REGEX: Regex = Regex::new(
-        r"bytes (\d+)-(\d+)/([0-9*]+)"
-    ).unwrap();
-  };
-  let content_range_captures = BYTES_REGEX.captures(content_range_value).unwrap();
-  
-  ContentRange {
-    // start_pos: content_range_captures.get(1).unwrap().as_str().parse::<u64>().unwrap(),
-    // end_pos: content_range_captures.get(2).unwrap().as_str().parse::<u64>().unwrap(),
-    total_length: content_range_captures.get(3).unwrap().as_str().parse::<u64>().unwrap(),
-  }
+    if !response.headers().contains_key(CONTENT_RANGE_HEADER_KEY) {
+        panic!("Range header not supported");
+    }
+    let content_range_value = response
+        .headers()
+        .get(CONTENT_RANGE_HEADER_KEY)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    lazy_static! {
+        static ref BYTES_REGEX: Regex = Regex::new(r"bytes (\d+)-(\d+)/([0-9*]+)").unwrap();
+    };
+    let content_range_captures = BYTES_REGEX.captures(content_range_value).unwrap();
+
+    ContentRange {
+        // start_pos: content_range_captures.get(1).unwrap().as_str().parse::<u64>().unwrap(),
+        // end_pos: content_range_captures.get(2).unwrap().as_str().parse::<u64>().unwrap(),
+        total_length: content_range_captures
+            .get(3)
+            .unwrap()
+            .as_str()
+            .parse::<u64>()
+            .unwrap(),
+    }
 }
 
 fn fetch_range(client: Client, url: String, range: Range) -> Response {
-  let response = client.get(url).headers(construct_headers(range)).send().unwrap();
-  response
+    client
+        .get(url)
+        .headers(construct_headers(range))
+        .send()
+        .unwrap()
 }
 
 struct DownloadPart {
-  start_pos: u64,
-  length: u64,
-  reader_channel: Sender<Vec<u8>>
+    start_pos: u64,
+    length: u64,
+    reader_channel: Sender<Vec<u8>>,
 }
 
 pub struct HttpChunkReader {
-  url: String,
-  length: u64,
-  read_size: u64,
-  total_size: u64,
-  coordinator: Option<Sender<Option<DownloadPart>>>,
-  reader_channel: Option<Receiver<Vec<u8>>>,
-  buf: Vec<u8>
+    url: String,
+    length: u64,
+    read_size: u64,
+    total_size: u64,
+    coordinator: Option<Sender<Option<DownloadPart>>>,
+    reader_channel: Option<Receiver<Vec<u8>>>,
+    buf: Vec<u8>,
 }
 
 impl HttpChunkReader {
-  pub fn new(url: String, total_size: u64) -> HttpChunkReader {
-    HttpChunkReader {
-      url,
-      length: total_size,
-      read_size: 0,
-      total_size,
-      coordinator: None,
-      reader_channel: None,
-      buf: Vec::new()
+    pub fn new(url: String, total_size: u64) -> HttpChunkReader {
+        HttpChunkReader {
+            url,
+            length: total_size,
+            read_size: 0,
+            total_size,
+            coordinator: None,
+            reader_channel: None,
+            buf: Vec::new(),
+        }
     }
-  }
 
-  pub async fn new_unknown_size(url: String) -> HttpChunkReader {
-    tokio::task::spawn_blocking(move || {
-      let response = fetch_range(Client::new(), url.clone(), Range::FromEnd(4));
-      let content_range = get_content_range(&response);
-      let magic_number = response.text().unwrap();
-      if magic_number != "PAR1" {
-        panic!("Not a parquet file");
-      }
-      Self::new(url.clone(), content_range.total_length)
-    }).await.unwrap()
-  }
+    pub async fn new_unknown_size(url: String) -> HttpChunkReader {
+        tokio::task::spawn_blocking(move || {
+            let response = fetch_range(Client::new(), url.clone(), Range::FromEnd(4));
+            let content_range = get_content_range(&response);
+            let magic_number = response.text().unwrap();
+            if magic_number != "PAR1" {
+                panic!("Not a parquet file");
+            }
+            Self::new(url, content_range.total_length)
+        })
+        .await
+        .unwrap()
+    }
 
-  pub fn start(&mut self) {
-    let (s, r) = bounded(0);
-    let url = self.url.clone();
-    self.coordinator = Some(s);
-    thread::spawn(move || {
-      loop {
-        match r.recv() {
-          result::Result::Ok(download_part_option) => {
-            let download_part = download_part_option.unwrap();
-            let url = url.clone();
-            thread::spawn(move || {
-              let mut response = fetch_range(Client::new(), url, Range::FromPositionTo(download_part.start_pos, download_part.start_pos + download_part.length -1));
-              loop {
-                let mut data: Vec<u8> = vec![0; 1024 * 64];
+    pub fn start(&mut self) {
+        let (s, r) = bounded(0);
+        let url = self.url.clone();
+        self.coordinator = Some(s);
+        thread::spawn(move || {
+            while let result::Result::Ok(download_part_option) = r.recv() {
+                let download_part = download_part_option.unwrap();
+                let url = url.clone();
+                thread::spawn(move || {
+                    let mut response = fetch_range(
+                        Client::new(),
+                        url,
+                        Range::FromPositionTo(
+                            download_part.start_pos,
+                            download_part.start_pos + download_part.length - 1,
+                        ),
+                    );
+                    loop {
+                        let mut data: Vec<u8> = vec![0; 1024 * 64];
 
-                match response.read(&mut data) {
-                  io::Result::Ok(len) => {
-                    let reader_channel = download_part.reader_channel.clone();  
-                    if len == 0 {
-                      return;
+                        match response.read(&mut data) {
+                            io::Result::Ok(len) => {
+                                let reader_channel = download_part.reader_channel.clone();
+                                if len == 0 {
+                                    return;
+                                }
+                                data.truncate(len);
+                                reader_channel.send(data).unwrap_or_else(|_err| {
+                                    // println!("{}", err)
+                                });
+                            }
+                            io::Result::Err(_) => unimplemented!(),
+                        };
                     }
-                    data.truncate(len);
-                    reader_channel.send(data).unwrap_or_else(|_err| {
-                      // println!("{}", err)
-                    });
-                  },
-                  io::Result::Err(_) => unimplemented!()
-                };
-              }        
-            });
-          },
-          result::Result::Err(_) => {
-            break
-          }
-        }        
-      }
-    });
-  }
+                });
+            }
+        });
+    }
 }
 
 impl Length for HttpChunkReader {
-  fn len(&self) -> u64 {
-      self.length
-  }
+    fn len(&self) -> u64 {
+        self.length
+    }
 }
 
 impl Read for HttpChunkReader {
-  fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-    match self.reader_channel.take() {
-      Some(reader_channel) => {
-        let remaining_size = (self.length - self.read_size) as usize;
-        if remaining_size > 0 {
-          let mut data = reader_channel.recv().unwrap();
-          let added_size = data.len();
-          self.read_size += added_size as u64;
-          let has_empty_buffer = self.buf.len() == 0;
-          if has_empty_buffer && buf.len() >= added_size {            
-            buf[0..added_size].copy_from_slice(&data[0..added_size]);
-            self.reader_channel = Some(reader_channel);
-            return Ok(added_size)
-          }
-          if has_empty_buffer {
-            self.buf = data;
-          } else {      
-            self.buf.append(&mut data);
-          }
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self.reader_channel.take() {
+            Some(reader_channel) => {
+                let remaining_size = (self.length - self.read_size) as usize;
+                if remaining_size > 0 {
+                    let mut data = reader_channel.recv().unwrap();
+                    let added_size = data.len();
+                    self.read_size += added_size as u64;
+                    if self.buf.is_empty() && buf.len() >= added_size {
+                        buf[0..added_size].copy_from_slice(&data[0..added_size]);
+                        self.reader_channel = Some(reader_channel);
+                        return Ok(added_size);
+                    }
+                    if self.buf.is_empty() {
+                        self.buf = data;
+                    } else {
+                        self.buf.append(&mut data);
+                    }
+                }
+                let readable_size = std::cmp::min(buf.len(), self.buf.len());
+                let drain = self.buf.drain(0..readable_size);
+                let data = drain.as_slice();
+                buf[0..readable_size as usize].copy_from_slice(&data[0..readable_size]);
+                self.reader_channel = Some(reader_channel);
+                Ok(readable_size)
+            }
+            None => unimplemented!(),
         }
-        let readable_size = std::cmp::min(buf.len(), self.buf.len());
-        let drain = self.buf.drain(0..readable_size);
-        let data = drain.as_slice();
-        buf[0..readable_size as usize]
-          .copy_from_slice(&data[0..readable_size]);
-        self.reader_channel = Some(reader_channel);
-        Ok(readable_size)
-      },
-      None => unimplemented!()
     }
-  }
 }
 
 impl ChunkReader for HttpChunkReader {
-  type T = HttpChunkReader;
+    type T = HttpChunkReader;
 
-  fn get_read(&self, start_pos: u64, length: usize) -> Result<Self::T> {
-    let (s, r) = bounded(0);
+    fn get_read(&self, start_pos: u64, length: usize) -> Result<Self::T> {
+        let (s, r) = bounded(0);
 
-    self.coordinator.clone().unwrap().send(Some(DownloadPart {
-      start_pos,
-      length: length as u64,
-      reader_channel: s
-    })).unwrap();
+        self.coordinator
+            .clone()
+            .unwrap()
+            .send(Some(DownloadPart {
+                start_pos,
+                length: length as u64,
+                reader_channel: s,
+            }))
+            .unwrap();
 
-    Ok(HttpChunkReader {
-      url: self.url.clone(),
-      length: length as u64,
-      read_size: 0,
-      total_size: self.total_size,
-      coordinator: self.coordinator.clone(),
-      reader_channel: Some(r),
-      buf: Vec::new()
-    })
-  }
+        Ok(HttpChunkReader {
+            url: self.url.clone(),
+            length: length as u64,
+            read_size: 0,
+            total_size: self.total_size,
+            coordinator: self.coordinator.clone(),
+            reader_channel: Some(r),
+            buf: Vec::new(),
+        })
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use rusoto_s3::{ListObjectsV2Output, ListObjectsV2Request, S3Client, S3};
 use url::Url;
 
 mod http_reader;
-use http_reader::{HttpChunkReader};
+use http_reader::HttpChunkReader;
 mod buzz;
 use buzz::{s3, CachedFile, RangeCache};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,11 +100,11 @@ async fn print_json_from(source: Source, offset: u32, limit: i32) {
 #[tokio::main]
 async fn main() {
     let matches = App::new("parquet2json")
-        .version("1.0")
+        .version("1.1.0")
         .about("Outputs Parquet as JSON")
         .arg(
             Arg::new("FILE")
-                .about("Location of Parquet input file (path or S3 URL)")
+                .about("Location of Parquet input file (path, HTTP or S3 URL)")
                 .required(true)
                 .index(1),
         )


### PR DESCRIPTION
The S3 reader does not support streaming and loads at least 1 row group before starting to output.

This adds an HTTP reader that works with Content Range headers such as supported by S3. You'd need to use a presigned S3 HTTP URL if you need to access private files on S3.