### PR TITLE
Reduce blocking receives in S3 Chunk Reader to improve performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "parquet2json"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "bytes",
  "chunked-bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parquet2json"
 description = "A command-line tool for converting Parquet to newline-delimited JSON"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2018"
 license = "MIT"
 authors = ["Pieter Raubenheimer <pieter@wavana.com>"]

--- a/src/s3_reader.rs
+++ b/src/s3_reader.rs
@@ -150,10 +150,10 @@ impl Length for S3ChunkReader {
 impl Read for S3ChunkReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let remaining_size = (self.length - self.read_size) as usize;
-        if remaining_size > 0 {
+        let self_buf = self.buf.get_mut();
+        if remaining_size > 0 && buf.len() > self_buf.remaining() {
             match self.reader_channel.take() {
                 Some(mut reader_channel) => {
-                    let self_buf = self.buf.get_mut();
                     let data = reader_channel.blocking_recv().unwrap();
                     let added_size = data.len();
                     self.read_size += added_size as u64;


### PR DESCRIPTION
Before:

```
        7.07 real         2.55 user         0.20 sys
            28655616  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               18049  page reclaims
                 290  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                 171  messages sent
                 425  messages received
                   1  signals received
                 487  voluntary context switches
                2116  involuntary context switches
         16029695646  instructions retired
          9637005358  cycles elapsed
            15941632  peak memory footprint
```

After:

```
        4.87 real         2.58 user         0.18 sys
            29425664  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               19057  page reclaims
                 290  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                 171  messages sent
                 443  messages received
                   1  signals received
                 176  voluntary context switches
                2314  involuntary context switches
         16076399320  instructions retired
          9711030073  cycles elapsed
            16695296  peak memory footprint
```