### PR TITLE
Use `arrow-array` `chrono-tz` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Pieter Raubenheimer <pieter@wavana.com>"]
 repository = "https://github.com/jupiter/parquet2json"
 
 [dependencies]
-arrow-array = { version = "52.0.0" }
+arrow-array = { version = "52.0.0", features = ["chrono-tz"] }
 arrow-cast = { version = "52.0.0" }
 arrow-json = { version = "52.0.0" }
 arrow-schema = { version = "52.0.0" }


### PR DESCRIPTION
I need this to avoid:

```
thread 'main' panicked at src/main.rs:194:56:
called `Result::unwrap()` on an `Err` value: ParseError("Invalid timezone \"US/Eastern\": only offset based timezones supported without chrono-tz feature")
stack backtrace:
   0: _rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: parquet2json::output_for_command::{{closure}}
   4: tokio::runtime::park::CachedParkThread::block_on
   5: tokio::runtime::runtime::Runtime::block_on
   6: parquet2json::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

when running `parquet2json cat` on some Parquet files.